### PR TITLE
fix: Fix label sync action

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,6 +19,6 @@
 - name: "Refactor"
   color: 000000
 - name: "Chore"
-  color: FEFAE0
+  color: FFFDDC
 - name: "Test"
   color: F6B26B

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,6 +1,7 @@
 name: Sync labels
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - .github/labels.yml
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed on this pull request

- Add permissions to the label sync action
- Add manual options to investigate more
- Minor fix

### Reference

https://github.com/brpaz/action-label-syncer?tab=readme-ov-file#permissions